### PR TITLE
서버 ip 를 유동적으로 사용할 수 있도록 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # Chat Server
+
+# # How To Run
+```bash
+./start.sh test
+```

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+npm install nodemon
+npm install babel-node

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "noom",
+  "name": "frontend_chat_server",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "noom",
+      "name": "frontend_chat_server",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "noom",
+  "name": "frontend_chat_server",
   "version": "1.0.0",
-  "description": "Zoom Clone using NodeJS, WebRTC and Websockets.",
+  "description": "frontend chat service with react",
   "license": "MIT",
   "scripts": {
     "dev": "nodemon"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "frontend chat service with react",
   "license": "MIT",
   "scripts": {
-    "dev": "nodemon"
+    "dev": "nodemon",
+    "start": "nodemon"
   },
   "devDependencies": {
     "@babel/cli": "^7.18.9",

--- a/src/public/js/app.js
+++ b/src/public/js/app.js
@@ -1,6 +1,9 @@
 const myUuid = document.getElementById("myUuid").innerText;
 document.getElementById("myUuid").innerText = "";
-const socket = io.connect("http://localhost:3000", { query: `uuid=${myUuid}`});
+const serverUrl = document.getElementById("serverUrl").innerText;
+document.getElementById("serverUrl").innerText = "";
+
+const socket = io.connect(serverUrl, { query: `uuid=${myUuid}`});
 
 const myFace = document.getElementById("myFace");
 const muteBtn = document.getElementById("mute");

--- a/src/server.js
+++ b/src/server.js
@@ -2,6 +2,7 @@ import http from 'http';
 import SocketIO from "socket.io";
 import express from 'express';
 import { v4 as uuidv4 } from 'uuid';
+import { serverInfo } from "./serverInfo";
 
 const app = express();
 
@@ -12,7 +13,8 @@ app.set("views", __dirname + "/views");
 app.use("/public", express.static(__dirname + "/public"));
 app.get("/", (req, res) => {
     res.render("home", {
-        uuid: uuidv4()
+        uuid: uuidv4(),
+        serverUrl: serverInfo["url"]
     });
 });
 app.get("/*", (req, res) => res.redirect("/"));
@@ -61,5 +63,5 @@ wsServer.on("connection", (socket) => {
     });
 });
 
-const handleListen = () => console.log("Listening on http://localhost:3000");
-httpServer.listen(3000, handleListen);
+const handleListen = () => console.log(`Listening on ${serverInfo["url"]}`);
+httpServer.listen(serverInfo["port"], handleListen);

--- a/src/serverInfo.js
+++ b/src/serverInfo.js
@@ -1,0 +1,7 @@
+const serverInfo = {
+    ip : process.env.SERVER_IP,
+    port : process.env.SERVER_PORT,
+    url : `http://${process.env.SERVER_IP}:${process.env.SERVER_PORT}`
+}
+
+export { serverInfo };

--- a/src/views/home.pug
+++ b/src/views/home.pug
@@ -6,6 +6,7 @@ html(lang="en")
         meta(name="viewport", content="width=device-width, initial-scale=1.0")
         title Noom
         span#myUuid(hidden=true) #{uuid}
+        span#serverUrl(hidden=true) #{serverUrl}
         //- link(rel="stylesheet", href="https://unpkg.com/mvp.css")
         link(rel="stylesheet", href="public/css/reset.css")
         link(rel="stylesheet", href="public/css/common.css")

--- a/start.sh
+++ b/start.sh
@@ -4,10 +4,16 @@ set -e
 
 print_usage()
 {
-	echo "USAGE : "
+	echo "[ USAGE ]"
 	echo "./start.sh [RUN_MODE]"
 	echo "RUN_MODE = \"real\" or \"test\""
 }
+
+if [ $# -lt 1 ]
+then
+print_usage
+exit
+fi
 
 if [ $1 = "real" ]
 then

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+print_usage()
+{
+	echo "USAGE : "
+	echo "./start.sh [RUN_MODE]"
+	echo "RUN_MODE = \"real\" or \"test\""
+}
+
+if [ $1 = "real" ]
+then
+export SERVER_IP=$(curl ifconfig.me)
+export SERVER_PORT=3000
+npm start
+elif [ $1 = "test" ]
+then
+export SERVER_IP="localhost"
+export SERVER_PORT=3000
+npm run dev
+else
+print_usage
+fi


### PR DESCRIPTION
# # 관련 이슈
#2 
# # 변경 사항
- start.sh 추가
- init.sh 추가
- 서버 ip, port 를 소스 코드에서 직접 박아두지 않고, 환경변수로 받아서 사용하도록 수정

# # 동작
- `./start.sh real` : 서버 public ip 를 확인해서 사용
- `./start.sh test` : localhost 를 서버 ip 로 사용
# # 실행 화면 예시
![image](https://user-images.githubusercontent.com/49180520/194768900-f47dfcb7-c8f4-4ece-9fd1-3b1c23c15ef5.png)

